### PR TITLE
chore(deps): Updates for additional AWS Regions support

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,20 +1,20 @@
-FROM registry:2.6.0
+FROM registry:2.7.1
 
 RUN apk add --no-cache \
-        python3 && \
+    python3 && \
     python3 -m ensurepip && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     ln -sf /usr/bin/pip3 /usr/bin/pip
 
 RUN buildDeps='gcc git linux-headers musl-dev python3-dev' && \
     apk add --no-cache $buildDeps && \
-    # "upgrade" boto to 2.43.0 + the patch to fix minio connections
+    # "upgrade" boto to 2.49.0: to support the latest AWS regions
     pip install --disable-pip-version-check --no-cache-dir --upgrade \
-        git+https://github.com/teamhephy/boto@abb38474ee5124bb571da0c42be67cd27c47094f \
-        azure==1.0.3 \
-        gcloud==0.18.3 \
-        python-swiftclient==3.1.0 \
-        python-keystoneclient==3.1.0 && \
+    boto==2.49.0 \
+    azure==1.0.3 \
+    gcloud==0.18.3 \
+    python-swiftclient==3.8.1 \
+    python-keystoneclient==3.1.0 && \
     # purge dev dependencies
     apk del $buildDeps
 

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,20 +1,20 @@
 FROM registry:2.7.1
 
 RUN apk add --no-cache \
-    python3 && \
+    	python3 && \
     python3 -m ensurepip && \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     ln -sf /usr/bin/pip3 /usr/bin/pip
 
 RUN buildDeps='gcc git linux-headers musl-dev python3-dev' && \
     apk add --no-cache $buildDeps && \
-    # "upgrade" boto to 2.49.0: to support the latest AWS regions
+    # "upgrade" boto to 2.49.0 to support the latest AWS regions
     pip install --disable-pip-version-check --no-cache-dir --upgrade \
-    boto==2.49.0 \
-    azure==1.0.3 \
-    gcloud==0.18.3 \
-    python-swiftclient==3.8.1 \
-    python-keystoneclient==3.1.0 && \
+    	boto==2.49.0 \
+    	azure==1.0.3 \
+    	gcloud==0.18.3 \
+    	python-swiftclient==3.8.1 \
+    	python-keystoneclient==3.1.0 && \
     # purge dev dependencies
     apk del $buildDeps
 


### PR DESCRIPTION
This PR upgrades to registry 2.7.1 and boto 2.49.0 in order to add support for newer AWS Regions.